### PR TITLE
Fixed minor typos

### DIFF
--- a/01._Setup_And_Basics/01._Workspaces.md
+++ b/01._Setup_And_Basics/01._Workspaces.md
@@ -88,9 +88,9 @@ Note: The `workspace list` commands outputs an empty line at the end which is no
 
 10. Reflect further on the usefulness of workspaces.
 
-Workspaces are used to isolate states. We have started provisioning resources yet, so there is no state to look at. 
+Workspaces are used to isolate states. We have not started provisioning resources yet, so there is no state to look at. 
 
-If there was a  state then they would exist in the `terraform.tfstate` in the `terraform.tfstate.d` directory. 
+If there was a state then they would exist in the `terraform.tfstate` in the `terraform.tfstate.d` directory. 
 
 When we switch a workspace then this file will be replaced to the one relevant to that particular workspace. 
 

--- a/01._Setup_And_Basics/01._Workspaces.md
+++ b/01._Setup_And_Basics/01._Workspaces.md
@@ -65,7 +65,7 @@ Note: The `workspace list` commands outputs an empty line at the end which is no
 <details> 
   <summary>Hint</summary>
     
-        $ terraform workspace create <your_name_here>
+        $ terraform workspace new <your_name_here>
 
 </details>
 

--- a/01._Setup_And_Basics/02._Getting_A_Provisioner.md
+++ b/01._Setup_And_Basics/02._Getting_A_Provisioner.md
@@ -19,7 +19,7 @@ It provides a [basic example](https://registry.terraform.io/providers/hashicorp/
 
 ## 1. Check out the content of "Example Usage" into main.tf
 
-We will lean against it since it aimts to be the most basic use of the provider.
+We will lean against it since it aims to be the most basic use of the provider.
 
 But it aims higher than we are going to in this project, which is to create a virtual machine. 
 

--- a/01._Setup_And_Basics/03._Specifying_Provier_Azurerm.md
+++ b/01._Setup_And_Basics/03._Specifying_Provier_Azurerm.md
@@ -62,12 +62,12 @@ This step is [optional] when working with Terraform but still useful because `te
 
 * ensures that all required arguments have been defined
 
-* validates the internal consistency of the entire confiuration setup
+* validates the internal consistency of the entire configuration setup
 
 However, it does not validate against the state, in fact, validate can be run against any uninitialized project. 
 
 
-## 4. [Optional] Let's the validate command:
+## 4. [Optional] Let's run the validate command:
 
 ```bash
 $ terraform validate
@@ -155,7 +155,7 @@ Uh oh, it fails as well. But this time the error is different:
 
 This section is to motivate why we are commiting mistakes on purpose. The above case is actually based on a real issue I had to solve. 
 
-I ran into the above problem (missing features block) by following online videos of a decently recenct video tutorial and I couldn't understand why their code didn't work for me. 
+I ran into the above problem (missing features block) by following online videos of a decently recenct video tutorial and I couldn't understand why their code worked, but didn't work for me. 
 
 It appears that the feautures block was introduced only after version`2.0` of `azurerm` and that it wasn't required previously. 
 

--- a/02._Basic_VM/03._tfvars.md
+++ b/02._Basic_VM/03._tfvars.md
@@ -15,8 +15,11 @@ variable "vm_name" {
 variable "vm_password" {
   description = "The admin password for the VM"
   type        = string
+  sensitive = true
 }
 ```
+
+> Note: Good practive to include the sensitive flag for sensitive information. Terraform will redact these values, from the terminal output when doing  `terraform apply` or `terraform plan`
 
 Run `terraform init` and for each following step run `terraform apply` to see the result. 
 
@@ -34,7 +37,7 @@ Feel free to change the password.
 
 3.  Import the tfvars File into Your Terraform Configuration
 
-By default, Terraform automatically loads all files in the same directory that end with `.tfvars` or `.tfvars.json`. If you named your file terraform.tfvars, there's no need for an explicit import statement. However, if you want to use a different file name or have multiple tfvars files, you can specify the file to load with the -var-file flag when running Terraform commands:
+By default, Terraform does not automatically loads all files in the same directory that end with `.tfvars` or `.tfvars.json`. Only if you named your file terraform.tfvars. However, if you want to use a different file name or have multiple tfvars files, you can specify the file to load with the -var-file flag when running Terraform commands:
 
 ```bash
 $ terraform apply -var-file="custom.tfvars"


### PR DESCRIPTION
This pull request includes corrections to documentation and improvements to Terraform configuration examples. The most important changes involve fixing typos, improving clarity in explanations, and enhancing best practices for sensitive data handling.

### Documentation Corrections and Improvements:
* [`01._Setup_And_Basics/01._Workspaces.md`](diffhunk://#diff-5067f1a390337e9236b616fba5cde304446c7c0f8b29a6b52dc913551fecd7fbL68-R68): Updated the command to create a workspace from `workspace create` to `workspace new` for accuracy. Corrected grammar in the explanation about provisioning resources. [[1]](diffhunk://#diff-5067f1a390337e9236b616fba5cde304446c7c0f8b29a6b52dc913551fecd7fbL68-R68) [[2]](diffhunk://#diff-5067f1a390337e9236b616fba5cde304446c7c0f8b29a6b52dc913551fecd7fbL91-R91)
* [`01._Setup_And_Basics/02._Getting_A_Provisioner.md`](diffhunk://#diff-2d9bdbbbc3c6af96f55d2696901671a941cdd8132ea1e82c6f69168fa867d1beL22-R22): Fixed a typo in the word "aimts," changing it to "aims."
* [`01._Setup_And_Basics/03._Specifying_Provier_Azurerm.md`](diffhunk://#diff-e80c9b0057b940fceb6f68c5f0881f5e889447b0a1d4558cc7c22233ae2e6717L65-R70): Corrected typos in "confiuration" and "recenct," and clarified the explanation about the `features` block in the `azurerm` provider. [[1]](diffhunk://#diff-e80c9b0057b940fceb6f68c5f0881f5e889447b0a1d4558cc7c22233ae2e6717L65-R70) [[2]](diffhunk://#diff-e80c9b0057b940fceb6f68c5f0881f5e889447b0a1d4558cc7c22233ae2e6717L158-R158)

### Terraform Best Practices:
* [`02._Basic_VM/03._tfvars.md`](diffhunk://#diff-eb4dc8199a8d73f1beac99fe2e0d22e904bab52eaca6797ecc60a4fb352fa8b1R18-R23): Added the `sensitive = true` flag to the `vm_password` variable to ensure sensitive information is redacted from terminal output.
* [`02._Basic_VM/03._tfvars.md`](diffhunk://#diff-eb4dc8199a8d73f1beac99fe2e0d22e904bab52eaca6797ecc60a4fb352fa8b1L37-R40): Clarified the behavior of Terraform when loading `.tfvars` files, emphasizing that only files named `terraform.tfvars` are automatically loaded.